### PR TITLE
[SLDEV-20374] Source Map Skipping Support

### DIFF
--- a/packages/istanbul-lib-instrument/package.json
+++ b/packages/istanbul-lib-instrument/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sl-istanbul-lib-instrument",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "original-version": "6.0.2",
   "description": "SL update to the core istanbul API for JS code coverage",
   "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
@@ -9,7 +9,7 @@
     "src"
   ],
   "scripts": {
-    "test": "nyc mocha"
+    "test": "node --max-old-space-size=10000 ./node_modules/.bin/nyc mocha"
   },
   "dependencies": {
     "@babel/core": "^7.23.9",

--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -27,6 +27,9 @@ const readInitialCoverage = require('./read-coverage');
  * @param {array} [opts.parserPlugins] - set babel parser plugins, see @istanbuljs/schema for defaults.
  * @param {string} [opts.coverageGlobalScope=this] the global coverage variable scope.
  * @param {boolean} [opts.coverageGlobalScopeFunc=true] use an evaluated function to find coverageGlobalScope.
+ * @param {boolean} [opts.skipFilesAndPackagePaths=[]] set to array of file paths and package paths to skip instrumenting.
+ * @param {boolean} [opts.skipInstrumentationIfNoSourceMap=false] set to true to skip instrumentation if no source map is provided.
+ * @param {boolean} [opts.customLogger=console] provide a custom logger to log errors and warnings.
  */
 class Instrumenter {
     constructor(opts = {}) {
@@ -81,8 +84,13 @@ class Instrumenter {
                             coverageGlobalScopeFunc:
                                 opts.coverageGlobalScopeFunc,
                             ignoreClassMethods: opts.ignoreClassMethods,
-                          instrumentLineLevel: opts.instrumentLineLevel,
-                            inputSourceMap
+                            instrumentLineLevel: opts.instrumentLineLevel,
+                            inputSourceMap,
+                            skipFilesAndPackagePaths:
+                                opts.skipFilesAndPackagePaths,
+                            skipInstrumentationIfNoSourceMap:
+                                opts.skipInstrumentationIfNoSourceMap,
+                            customLogger: opts.customLogger
                         });
 
                         return {


### PR DESCRIPTION
In this PR I added support for 2 separate functionalities, both behind an option that is by default disabled:

1. Allow skipping files without source-maps from instrumentation
2. Allow skipping source files from instrumentation based on the source-maps
3. Possibility to pass a customer logger 

Existing unit tests are passing.
![Screenshot 2025-03-11 at 14 46 25](https://github.com/user-attachments/assets/5d12f615-3301-4c1c-a61e-1ac671a3aa7c)
