### PR TITLE
chore: add ggshield pre-commit secret scanning

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,8 @@
+version: 2
+
+secret:
+  ignored-paths:
+    - "**/*.lock"
+    - "**/node_modules/**"
+    - "**/tsOutputs/**"
+    - "**/pnpm-lock.yaml"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.35.0
+    hooks:
+      - id: ggshield
+        language_version: python3
+        stages: [pre-commit]


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` to enable GitGuardian ggshield as a pre-commit hook via the `pre-commit` framework
- Add `.gitguardian.yaml` with sensible ignore paths

## Setup
```bash
pip install pre-commit
pre-commit install
```